### PR TITLE
Make projectID and preview API configurable

### DIFF
--- a/sample-app-android/README.md
+++ b/sample-app-android/README.md
@@ -33,3 +33,48 @@ Observable.fromCompletionStage(client.getItems(Article.class))
           // ...
         });
 ```
+
+### Using Appetize
+
+The application is preset to be able to consume data from different project (with the same scheme as in sample project). This feature is used for showcasing the application using [Appetize](https://appetize.io) service.
+
+To be able to consume the external configuration, the app checks whether the [Appetize Playback option - params](https://docs.appetize.io/core-features/playback-options) where provided and if so, it will reinitialize the client with specific project ID (and preview API key if provided).
+
+The decision logic is stored in `BaseActivity.java#onCreate` method.
+
+If you want to then use the Appetize you can create an Appetize iframe and provide `KontentProjectId` (and `KontentPreviewApiKey` if you what to use unpublished content) like this:
+
+```js
+  const queryParams = new URLSearchParams(window.location.search);
+
+    if (!queryParams.has("projectId")) {
+        console.error(`ProjectId parameter is not set in Content Type's preview URL`);
+    }
+
+    // contract defined by app's Kontent.ai client, user defaults, and Appetize's param API
+    const appetizeParams = {
+        KontentProjectId: queryParams.get("projectId"),
+    };
+
+    // if URL's got preview API key, add it to appetize params too
+    if (queryParams.has("previewApiKey")) {
+        appetizeParams.KontentPreviewApiKey = queryParams.get("previewApiKey")
+    }
+
+    // we want to pass projectId and API key params to appetize
+    const appetizeParamsStringifiedEncoded = encodeURIComponent(JSON.stringify(appetizeParams));
+    const appetizeUrl = `https://appetize.io/embed/<YOUR APP ID FROM APPETIZE>?device=pixel4&orientation=portrait&screenOnly=true&xdocMsg=true&params=${appetizeParamsStringifiedEncoded}`;
+
+    const appetizeIframe = document.createElement("iframe");
+    appetizeIframe.setAttribute("id", "appetize-iframe");
+    appetizeIframe.setAttribute("src", appetizeUrl);
+    appetizeIframe.setAttribute("height", "609");
+    appetizeIframe.setAttribute("width", "277");
+    appetizeIframe.setAttribute("scrolling", "no");
+    appetizeIframe.setAttribute("title", "iOS Preview Content");
+    appetizeIframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+
+    // and inject the iframe to DOM
+    const appetizeContainer = document.getElementById("appetize-container");
+    appetizeContainer.appendChild(appetizeIframe);
+```

--- a/sample-app-android/README.md
+++ b/sample-app-android/README.md
@@ -42,7 +42,9 @@ To be able to consume the external configuration, the app checks whether the [Ap
 
 The decision logic is stored in `BaseActivity.java#onCreate` method.
 
-If you want to use the Appetize you can create an Appetize iframe and provide `KontentProjectId` (and `KontentPreviewApiKey` if you want to use unpublished content) like this:
+#### Embed your app to HTML using Appetize
+
+If you want [embed your application to a website using Appetize](https://docs.appetize.io/core-features/embed-your-app) you can create an `iframe` via JavaScript to provide `KontentProjectId` (and `KontentPreviewApiKey` if you want to use unpublished content) paramters.
 
 ```js
   const queryParams = new URLSearchParams(window.location.search);

--- a/sample-app-android/README.md
+++ b/sample-app-android/README.md
@@ -44,7 +44,7 @@ The decision logic is stored in `BaseActivity.java#onCreate` method.
 
 #### Embed your app to HTML using Appetize
 
-If you want [embed your application to a website using Appetize](https://docs.appetize.io/core-features/embed-your-app) you can create an `iframe` via JavaScript to provide `KontentProjectId` (and `KontentPreviewApiKey` if you want to use unpublished content) paramters.
+If you want [embed your application to a website using Appetize](https://docs.appetize.io/core-features/embed-your-app) you can create an `iframe` via JavaScript to provide `KontentProjectId` (and `KontentPreviewApiKey` if you want to use unpublished content) parameters.
 
 ```js
   const queryParams = new URLSearchParams(window.location.search);

--- a/sample-app-android/README.md
+++ b/sample-app-android/README.md
@@ -42,7 +42,7 @@ To be able to consume the external configuration, the app checks whether the [Ap
 
 The decision logic is stored in `BaseActivity.java#onCreate` method.
 
-If you want to then use the Appetize you can create an Appetize iframe and provide `KontentProjectId` (and `KontentPreviewApiKey` if you what to use unpublished content) like this:
+If you want to use the Appetize you can create an Appetize iframe and provide `KontentProjectId` (and `KontentPreviewApiKey` if you want to use unpublished content) like this:
 
 ```js
   const queryParams = new URLSearchParams(window.location.search);

--- a/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/app/core/BaseActivity.java
+++ b/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/app/core/BaseActivity.java
@@ -28,6 +28,7 @@ import kontent.ai.delivery_android_sample.R;
 import kontent.ai.delivery_android_sample.app.articles.ArticlesActivity;
 import kontent.ai.delivery_android_sample.app.cafes.CafesActivity;
 import kontent.ai.delivery_android_sample.app.coffees.CoffeesActivity;
+import kontent.ai.delivery_android_sample.data.source.DeliveryClientProvider;
 import kontent.ai.delivery_android_sample.util.NetworkHelper;
 
 public abstract class BaseActivity extends AppCompatActivity {
@@ -80,6 +81,14 @@ public abstract class BaseActivity extends AppCompatActivity {
         // init android networking
         // TODO: seems like this is not required after all, verify and remove if possible
         //AndroidNetworking.initialize(getApplicationContext());
+
+        String customProjectId = getIntent().getStringExtra("KontentProjectId");
+        String customPreviewAPiKey = getIntent().getStringExtra("KontentPreviewApiKey");
+
+        if(customProjectId != null)
+        {
+            DeliveryClientProvider.resetClient(customProjectId, customPreviewAPiKey);
+        }
 
         // Init network helper
         this.networkHelper = NetworkHelper.getInstance();

--- a/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/app/core/BaseActivity.java
+++ b/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/app/core/BaseActivity.java
@@ -87,7 +87,7 @@ public abstract class BaseActivity extends AppCompatActivity {
 
         if(customProjectId != null)
         {
-            DeliveryClientProvider.resetClient(customProjectId, customPreviewAPiKey);
+            DeliveryClientProvider.initializeClient(customProjectId, customPreviewAPiKey);
         }
 
         // Init network helper

--- a/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/data/source/DeliveryClientProvider.java
+++ b/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/data/source/DeliveryClientProvider.java
@@ -19,18 +19,18 @@ public class DeliveryClientProvider {
 
     public static DeliveryClient getClient() {
         if (INSTANCE == null) {
-            DeliveryClient client = resetClient(AppConfig.KONTENT_PROJECT_ID);
+            DeliveryClient client = initializeClient(AppConfig.KONTENT_PROJECT_ID);
             INSTANCE = client;
         }
         return INSTANCE;
     }
 
-    private static DeliveryClient resetClient(String previewAPiKey) {
-        return resetClient(previewAPiKey, null);
+    private static DeliveryClient initializeClient(String projectId) {
+        return initializeClient(projectId, null);
     }
 
 
-    public static DeliveryClient resetClient(String projectId, String previewAPiKey) {
+    public static DeliveryClient initializeClient(String projectId, String previewAPiKey) {
         DeliveryOptions.DeliveryOptionsBuilder optionsBuilder = DeliveryOptions
                 .builder()
                 .projectId(projectId)

--- a/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/data/source/DeliveryClientProvider.java
+++ b/sample-app-android/src/main/java/kontent/ai/delivery_android_sample/data/source/DeliveryClientProvider.java
@@ -19,21 +19,40 @@ public class DeliveryClientProvider {
 
     public static DeliveryClient getClient() {
         if (INSTANCE == null) {
-            DeliveryClient client = new DeliveryClient(
-                    DeliveryOptions
-                            .builder()
-                            .projectId(AppConfig.KONTENT_PROJECT_ID)
-                            .customHeaders(Arrays.asList(
-                                    new Header(TRACKING_HEADER_NAME, TRACKING_HEADER_VALUE)
-                            ))
-                            .build(),
-                    null
-            );
-            client.registerType(Article.class);
-            client.registerType(Cafe.class);
-            client.registerType(Coffee.class);
+            DeliveryClient client = resetClient(AppConfig.KONTENT_PROJECT_ID);
             INSTANCE = client;
         }
+        return INSTANCE;
+    }
+
+    private static DeliveryClient resetClient(String previewAPiKey) {
+        return resetClient(previewAPiKey, null);
+    }
+
+
+    public static DeliveryClient resetClient(String projectId, String previewAPiKey) {
+        DeliveryOptions.DeliveryOptionsBuilder optionsBuilder = DeliveryOptions
+                .builder()
+                .projectId(projectId)
+                .customHeaders(Arrays.asList(
+                        new Header(TRACKING_HEADER_NAME, TRACKING_HEADER_VALUE)
+                ));
+
+        if (previewAPiKey != null) {
+            optionsBuilder = optionsBuilder
+                    .previewApiKey(previewAPiKey)
+                    .usePreviewApi(true);
+        }
+
+        DeliveryClient client = new DeliveryClient(
+                optionsBuilder.build(),
+                null
+        );
+
+        client.registerType(Article.class);
+        client.registerType(Cafe.class);
+        client.registerType(Coffee.class);
+        INSTANCE = client;
         return INSTANCE;
     }
 }


### PR DESCRIPTION
### Motivation

Internal link: DEVREL-694

Make the project Id and preview API key configurable. Currently using getIntent.getStringExtra().

* In combination with appetize it can be configurable => check i.e. https://github.com/kontent-ai/safelife-appetize-iframe

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
